### PR TITLE
Convert basestring to string_types in s3_bucket

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -119,6 +119,7 @@ import traceback
 import xml.etree.ElementTree as ET
 
 import ansible.module_utils.six.moves.urllib.parse as urlparse
+from ansible.module_utils.six import string_types
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec
 from ansible.module_utils.ec2 import sort_json_policy_dict
@@ -210,7 +211,7 @@ def _create_or_update_bucket(connection, module, location):
         else:
             module.fail_json(msg=e.message)
     if policy is not None:
-        if isinstance(policy, basestring):
+        if isinstance(policy, string_types):
             policy = json.loads(policy)
 
         if not policy:


### PR DESCRIPTION
##### SUMMARY

Converts use of `basestring` to `string_types` to make the `s3_bucket` module work in Python 3

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

s3_bucket

##### ANSIBLE VERSION

```
ansible 2.3.0.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 3.6.1 (default, Mar 22 2017, 06:17:05) [GCC 6.3.0 20170321]
```


##### ADDITIONAL INFORMATION

The error that occurs without this change:

```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_w_c0vixh/ansible_module_s3_bucket.py", line 444, in <module>
    main()
  File "/tmp/ansible_w_c0vixh/ansible_module_s3_bucket.py", line 439, in main
    create_or_update_bucket(connection, module, location, flavour=flavour)
  File "/tmp/ansible_w_c0vixh/ansible_module_s3_bucket.py", line 324, in create_or_update_bucket
    _create_or_update_bucket(connection, module, location)
  File "/tmp/ansible_w_c0vixh/ansible_module_s3_bucket.py", line 214, in _create_or_update_bucket
    if isinstance(policy, basestring):
NameError: name 'basestring' is not defined
```
