### PR TITLE
Fixing policy sorting for Python 3

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -570,7 +570,9 @@ def sort_json_policy_dict(policy_dict):
             else:
                 checked_list.append(item)
 
-        checked_list.sort()
+        # Sort list. If it's a list of dictionaries, sort by tuple of key-value
+        # pairs, since Python 3 doesn't allow comparisons such as `<` between dictionaries.
+        checked_list.sort(key=lambda x: sorted(x.items()) if isinstance(x, dict) else x)
         return checked_list
 
     ordered_policy_dict = {}


### PR DESCRIPTION
##### SUMMARY

Fixing sorting issue for ordering policy statements in Python 3

Python 3 doesn't allow dictionaries to be compared directly, e.g. this is disallowed: `{'foo': 1} < {'bar': 2}`. However, we can emulate the Python 2 behavior and choose some ordering, though the particular one one chosen isn't important.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ec2

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 3.6.1 (default, Mar 22 2017, 06:17:05) [GCC 6.3.0 20170321]
```


##### ADDITIONAL INFORMATION

The error that happens without this change:

```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_nj8wmvub/ansible_module_s3_bucket.py", line 444, in <module>
    main()
  File "/tmp/ansible_nj8wmvub/ansible_module_s3_bucket.py", line 439, in main
    create_or_update_bucket(connection, module, location, flavour=flavour)
  File "/tmp/ansible_nj8wmvub/ansible_module_s3_bucket.py", line 324, in create_or_update_bucket
    _create_or_update_bucket(connection, module, location)
  File "/tmp/ansible_nj8wmvub/ansible_module_s3_bucket.py", line 222, in _create_or_update_bucket
    elif sort_json_policy_dict(current_policy) != sort_json_policy_dict(policy):
  File "/tmp/ansible_nj8wmvub/ansible_modlib.zip/ansible/module_utils/ec2.py", line 576, in sort_json_policy_dict
  File "/tmp/ansible_nj8wmvub/ansible_modlib.zip/ansible/module_utils/ec2.py", line 568, in value_is_list
TypeError: '<' not supported between instances of 'dict' and 'dict'
```
